### PR TITLE
Allow linking to external style sheet

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,8 +50,9 @@ You can further customize the source block output with additional Rouge attribut
 
 rouge-css::
   Controls what method is used for applying CSS to the tokens.
-  Can be `class` (CSS classes) or `style` (inline styles).
+  Can be `class` (CSS classes), `style` (inline styles) or `external` (external styles).
   When `class` is used, Rouge styles for the specified theme are included in an HTML header.
+  When `external` is specified, CSS classes are used but no styles will be added except when `rouge-theme` is not empty in which case its value is interpreted as a URL to a style sheet and a link to that style sheet will be added to the HTML header.
   Default is `class`.
 
 rouge-theme::

--- a/lib/asciidoctor/rouge/docinfo_processor.rb
+++ b/lib/asciidoctor/rouge/docinfo_processor.rb
@@ -12,11 +12,19 @@ module Asciidoctor::Rouge
     # @return [String, nil]
     def process(document)
       return unless document.attr?('source-highlighter', 'rouge')
-      return unless document.attr('rouge-css', 'class') == 'class'
+      style = document.attr('rouge-css', 'class')
 
-      if (theme = ::Rouge::Theme.find(document.attr('rouge-theme', DEFAULT_THEME)))
-        css = theme.render(scope: '.highlight')
-        ['<style>', css, '</style>'].join("\n")
+      if (style == 'class')
+        if (theme = ::Rouge::Theme.find(document.attr('rouge-theme', DEFAULT_THEME)))
+          css = theme.render(scope: '.highlight')
+          ['<style>', css, '</style>'].join("\n")
+        end
+      elsif (style == 'external')
+        if (theme = document.attr('rouge-theme'))
+          ['<link rel="stylesheet" href="', theme, '">'].join("")
+        end
+      else
+        return
       end
     end
   end


### PR DESCRIPTION
Hi,

I think in some cases it may be useful to use CSS classes but not insert the styles into the generated document (because they get included elsewhere) or just link to an external style-sheet which is maintained outside of Rouge.

Exactly this can be achieved with this change with adds the new `external` option to the `rouge-css` attribute. This change shouldn't introduce any changes to the current functionality.

Best regards,
Volker