### PR TITLE
Fancy find

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,8 +50,9 @@ You can further customize the source block output with additional Rouge attribut
 
 rouge-css::
   Controls what method is used for applying CSS to the tokens.
-  Can be `class` (CSS classes) or `style` (inline styles).
+  Can be `class` (CSS classes), `style` (inline styles) or `external` (external styles).
   When `class` is used, Rouge styles for the specified theme are included in an HTML header.
+  When `external` is specified, CSS classes are used but no styles will be added except when `rouge-theme` is not empty in which case its value is interpreted as a URL to a style sheet and a link to that style sheet will be added to the HTML header.
   Default is `class`.
 
 rouge-theme::

--- a/README.adoc
+++ b/README.adoc
@@ -64,6 +64,22 @@ rouge-style::
   Alternative name for the `rouge-theme` for compatibility with _asciidoctor-pdf_ (see https://github.com/{gh-name}/issues/3[#3]).
 
 
+=== Passing CGI-style options for selected language
+
+Rouge allows passing https://github.com/jneen/rouge#you-can-even-use-it-with-redcarpet[certain options] to its Lexer classes when selecting the language to parse. This feature is also available from within Asciidoctor. So instead of simply writing:
+
+```
+[source, console]
+```
+
+to select `console` as output language (with its default options) you can also write:
+
+```
+[source, "console?prompt=$> "]
+```
+
+This will also select `console` as output language but it will additionally set the prompt string to ``$> ``. Options are comma separeted `key=value` pairs which are appended to the language string with a `?`-character. Consult the various https://www.rubydoc.info/gems/rouge/Rouge/Lexers[Rouge Lexer] classes to find out which additional options they support.
+
 == License
 
 This project is licensed under http://opensource.org/licenses/MIT/[MIT License].

--- a/lib/asciidoctor/rouge/docinfo_processor.rb
+++ b/lib/asciidoctor/rouge/docinfo_processor.rb
@@ -12,11 +12,19 @@ module Asciidoctor::Rouge
     # @return [String, nil]
     def process(document)
       return unless document.attr?('source-highlighter', 'rouge')
-      return unless document.attr('rouge-css', 'class') == 'class'
+      style = document.attr('rouge-css', 'class')
 
-      if (theme = ::Rouge::Theme.find(document.attr('rouge-theme', DEFAULT_THEME)))
-        css = theme.render(scope: '.highlight')
-        ['<style>', css, '</style>'].join("\n")
+      if (style == 'class')
+        if (theme = ::Rouge::Theme.find(document.attr('rouge-theme', DEFAULT_THEME)))
+          css = theme.render(scope: '.highlight')
+          ['<style>', css, '</style>'].join("\n")
+        end
+      elsif (style == 'external')
+        if (theme = document.attr('rouge-theme'))
+          ['<link rel="stylesheet" href="', theme, '">'].join("")
+        end
+      else
+        return
       end
     end
   end

--- a/lib/asciidoctor/rouge/treeprocessor.rb
+++ b/lib/asciidoctor/rouge/treeprocessor.rb
@@ -116,7 +116,7 @@ module Asciidoctor::Rouge
     # @param language [String]
     # @return [Rouge::Lexer] a lexer for the specified *language*.
     def find_lexer(language)
-      (::Rouge::Lexer.find(language) || ::Rouge::Lexers::PlainText).new
+      (::Rouge::Lexer.find_fancy(language) || ::Rouge::Lexers::PlainText.new)
     end
 
     # @param source [String] the code to highlight.


### PR DESCRIPTION
Hi,

this is an extension of my initial pull request (https://github.com/jirutka/asciidoctor-rouge/pull/8) which uses `Lexer.find_fancy()` instead of `Lexer.find()` in order to allow passing CGI-style options to the specific language Lexer. More details can be found in README.adoc.

Thanks for providing asciidoctor-rouge and a happy new year!