### PR TITLE
Better configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,8 +50,9 @@ You can further customize the source block output with additional Rouge attribut
 
 rouge-css::
   Controls what method is used for applying CSS to the tokens.
-  Can be `class` (CSS classes) or `style` (inline styles).
+  Can be `class` (CSS classes), `style` (inline styles) or `external` (external styles).
   When `class` is used, Rouge styles for the specified theme are included in an HTML header.
+  When `external` is specified, CSS classes are used but no styles will be added except when `rouge-theme` is not empty in which case its value is interpreted as a URL to a style sheet and a link to that style sheet will be added to the HTML header.
   Default is `class`.
 
 rouge-theme::

--- a/README.adoc
+++ b/README.adoc
@@ -64,6 +64,22 @@ rouge-style::
   Alternative name for the `rouge-theme` for compatibility with _asciidoctor-pdf_ (see https://github.com/{gh-name}/issues/3[#3]).
 
 
+=== Passing CGI-style options for selected language
+
+Rouge allows passing https://github.com/jneen/rouge#you-can-even-use-it-with-redcarpet[certain options] to its Lexer classes when selecting the language to parse. This feature is also available from within Asciidoctor. So instead of simply writing:
+
+```
+[source, console]
+```
+
+to select `console` as output language (with its default options) you can also write:
+
+```
+[source, "console?prompt=$> "]
+```
+
+This will also select `console` as output language but it will additionally set the prompt string to ``$> ``. Options are comma separeted `key=value` pairs which are appended to the language string with a `?`-character. Consult the various https://www.rubydoc.info/gems/rouge/Rouge/Lexers[Rouge Lexer] classes to find out which additional options they support.
+
 == License
 
 This project is licensed under http://opensource.org/licenses/MIT/[MIT License].

--- a/README.adoc
+++ b/README.adoc
@@ -63,6 +63,17 @@ rouge-theme::
 rouge-style::
   Alternative name for the `rouge-theme` for compatibility with _asciidoctor-pdf_ (see https://github.com/{gh-name}/issues/3[#3]).
 
+rouge-highlighted-class::
+  CSS class to use on a line wrapper element for highlighted lines.
+  Default is `highlighted`.
+
+rouge-line-class::
+  CSS class to set on a line wrapper element
+  Default is `line`.
+
+rouge-line-id::
+  Format string for specifying an HTML `id` for each line (e.g. with `rouge-line-id="L%i"` each line of the listing will get an id of the form `id="L1"`, `id="L2"`, etc.). This really only makes sense if the format string is distinct for each source listing, otherwise it will lead to duplicate IDs which makes the generated HTML invalid.
+  Default is no line ids.
 
 === Passing CGI-style options for selected language
 

--- a/lib/asciidoctor/rouge.rb
+++ b/lib/asciidoctor/rouge.rb
@@ -6,6 +6,17 @@ require 'asciidoctor/rouge/docinfo_processor'
 require 'asciidoctor/rouge/treeprocessor'
 
 Asciidoctor::Extensions.register do
-  treeprocessor Asciidoctor::Rouge::Treeprocessor
+  opts = {}
+  # Allow the user to override the following attributes for the whole document
+  # on the comamnd line (e.g. '-a rouge-highlighted-class=my-highlight')
+  highlighted_class = document.attr('rouge-highlighted-class')
+  opts[:highlighted_class] = highlighted_class if highlighted_class
+  line_class = document.attr('rouge-line-class')
+  opts[:line_class] = line_class if line_class
+  # A single line ID pattern for the whole document doesn't make much sense
+  # because it will most probably produce non-unige IDs. So reset to 'nil'
+  # by default (i.e. if 'rouge-line-id' isn't given on the command line)
+  opts[:line_id] = document.attr('rouge-line-id')
+  tree_processor(Asciidoctor::Rouge::Treeprocessor, formatter_opts: opts)
   docinfo_processor Asciidoctor::Rouge::DocinfoProcessor
 end

--- a/lib/asciidoctor/rouge/docinfo_processor.rb
+++ b/lib/asciidoctor/rouge/docinfo_processor.rb
@@ -12,11 +12,19 @@ module Asciidoctor::Rouge
     # @return [String, nil]
     def process(document)
       return unless document.attr?('source-highlighter', 'rouge')
-      return unless document.attr('rouge-css', 'class') == 'class'
+      style = document.attr('rouge-css', 'class')
 
-      if (theme = ::Rouge::Theme.find(document.attr('rouge-theme', DEFAULT_THEME)))
-        css = theme.render(scope: '.highlight')
-        ['<style>', css, '</style>'].join("\n")
+      if (style == 'class')
+        if (theme = ::Rouge::Theme.find(document.attr('rouge-theme', DEFAULT_THEME)))
+          css = theme.render(scope: '.highlight')
+          ['<style>', css, '</style>'].join("\n")
+        end
+      elsif (style == 'external')
+        if (theme = document.attr('rouge-theme'))
+          ['<link rel="stylesheet" href="', theme, '">'].join("")
+        end
+      else
+        return
       end
     end
   end

--- a/lib/asciidoctor/rouge/treeprocessor.rb
+++ b/lib/asciidoctor/rouge/treeprocessor.rb
@@ -116,7 +116,7 @@ module Asciidoctor::Rouge
     # @param language [String]
     # @return [Rouge::Lexer] a lexer for the specified *language*.
     def find_lexer(language)
-      (::Rouge::Lexer.find(language) || ::Rouge::Lexers::PlainText).new
+      (::Rouge::Lexer.find_fancy(language) || ::Rouge::Lexers::PlainText.new)
     end
 
     # @param source [String] the code to highlight.

--- a/lib/asciidoctor/rouge/treeprocessor.rb
+++ b/lib/asciidoctor/rouge/treeprocessor.rb
@@ -105,6 +105,17 @@ module Asciidoctor::Rouge
         opts[:highlighted_lines] = resolve_lines_to_highlight(block, source)
       end
 
+      # Line ID patterns only make sense if they are unique for each source
+      # block, otherwise they can lead to non-unique IDs within the document.
+      # We only allow setting them on a source block and not for the document.
+      line_id = block.attr('rouge-line-id', nil, false)
+      opts[:line_id] = line_id if line_id
+      # Allow overriding of the following attributes
+      highlighted_class = block.attr('rouge-highlighted-class')
+      opts[:highlighted_class] = highlighted_class if highlighted_class
+      line_class = block.attr('rouge-line-class')
+      opts[:line_class] = line_class if line_class
+
       opts[:callout_markers] = callouts.method(:convert_line) if callouts
 
       result = highlight(source, lexer, opts)


### PR DESCRIPTION
Allow configuration of highlighted_class, line_class and line_id (globally, per document and per source block) and disable line_id by default to prevent the creation of non-unique IDs.

More detailed description is in README.adoc